### PR TITLE
Add travis CI fixes

### DIFF
--- a/include/xue.h
+++ b/include/xue.h
@@ -119,17 +119,17 @@ static inline uint64_t xue_sys_virt_to_dma(void *, const void *virt)
 #include <arch/x64/cache.h>
 #include <arch/x64/portio.h>
 #include <cstdio>
-#include <string>
 #include <debug/serial/serial_ns16550a.h>
 #include <memory_manager/arch/x64/cr3.h>
 #include <memory_manager/memory_manager.h>
+#include <string>
 
 static_assert(XUE_PAGE_SIZE == BAREFLANK_PAGE_SIZE);
 extern "C" void debug_ring_write(const std::string &str);
 
 #define xue_printf(...)                                                        \
     do {                                                                       \
-        char buf[256]{0};                                                      \
+        char buf[256] { 0 };                                                   \
         snprintf(buf, 256, __VA_ARGS__);                                       \
         debug_ring_write(buf);                                                 \
     } while (0)
@@ -219,8 +219,8 @@ extern "C" {
 
 /* Linux driver */
 #if defined(MODULE) && defined(__linux__)
-#include <asm/io.h>
 #include <asm/cacheflush.h>
+#include <asm/io.h>
 #include <linux/printk.h>
 #include <linux/slab.h>
 #include <linux/types.h>
@@ -662,7 +662,7 @@ static inline void xue_sys_pause(void *sys)
 static inline void xue_sys_clflush(void *sys, void *ptr)
 {
     (void)sys;
-    __asm volatile("clflush %0" : "+m" (*(volatile char *)ptr));
+    __asm volatile("clflush %0" : "+m"(*(volatile char *)ptr));
 }
 
 #endif
@@ -694,7 +694,7 @@ static inline void xue_sys_pause(void *sys)
 static inline void xue_sys_clflush(void *sys, void *ptr)
 {
     (void)sys;
-    __asm volatile("clflush %0" : "+m" (*(volatile char *)ptr));
+    __asm volatile("clflush %0" : "+m"(*(volatile char *)ptr));
 }
 
 static inline void *xue_sys_alloc_dma(void *sys, uint64_t order)
@@ -1301,9 +1301,8 @@ static inline void xue_push_trb(struct xue *xue, struct xue_trb_ring *ring,
     xue->trbs_written++;
 }
 
-static inline int64_t xue_push_work(struct xue *xue,
-                                    struct xue_work_ring *ring, const char *buf,
-                                    int64_t len)
+static inline int64_t xue_push_work(struct xue *xue, struct xue_work_ring *ring,
+                                    const char *buf, int64_t len)
 {
     int64_t i = 0;
     uint32_t start = ring->enq;
@@ -1779,7 +1778,8 @@ static inline void xue_flush(struct xue *xue, struct xue_trb_ring *trb,
         xue_push_trb(xue, trb, wrk->dma + wrk->deq, wrk->enq - wrk->deq);
         wrk->deq = wrk->enq;
     } else {
-        xue_push_trb(xue, trb, wrk->dma + wrk->deq, XUE_WORK_RING_CAP - wrk->deq);
+        xue_push_trb(xue, trb, wrk->dma + wrk->deq,
+                     XUE_WORK_RING_CAP - wrk->deq);
         wrk->deq = 0;
         if (wrk->enq > 0 && !xue_trb_ring_full(trb)) {
             xue_push_trb(xue, trb, wrk->dma, wrk->enq);

--- a/test/test_xue.cpp
+++ b/test/test_xue.cpp
@@ -19,6 +19,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#define XUE_TRB_RING_ORDER 0
+
 #include <array>
 #include <catch2/catch.hpp>
 #include <cstdio>
@@ -48,11 +50,13 @@ uint32_t pci_reg{};
 
 std::array<uint32_t, 64> xhc_cfg{};
 std::array<uint8_t, xhc_mmio_size> xhc_mmio{};
-std::array<uint32_t, 4> known_xhc_list{
+
+std::array<uint32_t, 5> known_xhc_list = {
     (XUE_XHC_DEV_Z370 << 16) | XUE_XHC_VEN_INTEL,
     (XUE_XHC_DEV_Z390 << 16) | XUE_XHC_VEN_INTEL,
     (XUE_XHC_DEV_WILDCAT_POINT << 16) | XUE_XHC_VEN_INTEL,
-    (XUE_XHC_DEV_SUNRISE_POINT << 16) | XUE_XHC_VEN_INTEL
+    (XUE_XHC_DEV_SUNRISE_POINT << 16) | XUE_XHC_VEN_INTEL,
+    (XUE_XHC_DEV_CANNON_POINT << 16) | XUE_XHC_VEN_INTEL
 };
 
 constexpr auto dbc_offset = 0x8000U;
@@ -407,7 +411,7 @@ TEST_CASE("xue_push_trb")
     CHECK(ring.cyc == 1);
 
     for (auto i = 0UL; i < XUE_TRB_RING_CAP; i++) {
-        xue_push_trb(&ring, i, 1);
+        xue_push_trb(&xue, &ring, i, 1);
     }
 
     CHECK(ring.enq == 1);
@@ -438,9 +442,9 @@ TEST_CASE("xue_push_work")
     for (auto i = 0UL; i < XUE_WORK_RING_CAP; i++) {
         char buf[1] = {1};
         if (i < XUE_WORK_RING_CAP - 1) {
-            CHECK(xue_push_work(&ring, buf, 1) == 1);
+            CHECK(xue_push_work(&xue, &ring, buf, 1) == 1);
         } else {
-            CHECK(xue_push_work(&ring, buf, 1) == 0);
+            CHECK(xue_push_work(&xue, &ring, buf, 1) == 0);
         }
     }
 


### PR DESCRIPTION
- Fix Bareflank build by using inline assembly for lfence and sfence
  instead of ::intel_x64::{rmb,wmb} functions. These are not
  present in upstream Bareflank.
- Add #define for TRB ring order for unit testing
- Add clang-format changes