### PR TITLE
Add support for new chipset

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ tested to work:
 
   - Z370 (PCI device 0xA2AF)
   - Z390 (PCI device 0xA36D)
+  - Series 100/C230 (PCI device 0xA12F)
   - Wildcat Point-LP (PCI device 0x9CB1)
   - Sunrise Point-LP (PCI device 0x9D2F)
   - Cannon Point-LP (PCI device 0x9DED)

--- a/include/xue.h
+++ b/include/xue.h
@@ -30,6 +30,7 @@
 /* Supported xHC PCI configurations */
 #define XUE_XHC_CLASSC 0xC0330ULL
 #define XUE_XHC_VEN_INTEL 0x8086ULL
+#define XUE_XHC_DEV_C230 0xA12FULL
 #define XUE_XHC_DEV_Z370 0xA2AFULL
 #define XUE_XHC_DEV_Z390 0xA36DULL
 #define XUE_XHC_DEV_WILDCAT_POINT 0x9CB1ULL
@@ -62,6 +63,7 @@
 static inline int known_xhc(uint32_t dev_ven)
 {
     switch (dev_ven) {
+    case (XUE_XHC_DEV_C230 << 16) | XUE_XHC_VEN_INTEL:
     case (XUE_XHC_DEV_Z370 << 16) | XUE_XHC_VEN_INTEL:
     case (XUE_XHC_DEV_Z390 << 16) | XUE_XHC_VEN_INTEL:
     case (XUE_XHC_DEV_WILDCAT_POINT << 16) | XUE_XHC_VEN_INTEL:


### PR DESCRIPTION
Series 100/C230 chipset (PCI device 0xA12F) used in HP Z240 workstations and others
This was tested with actual hardware